### PR TITLE
fix; add windows smoldb.exe file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/**
 compile_commands.json
 .vscode
 **/smoldb
+**/smoldb.exe


### PR DESCRIPTION
# Add Window's executable (smoldb.exe) into gitignore

- **What**:

Add Windows's executable (smoldb.exe) into gitignore

- **Why**:

Git ignores the smoldb executable on UNIX, yes, but since Windows executables have the .exe extension also, it doesn't.

- **How**:

I modified gitignore, simply.


- **Tags**:

@nguyenhuy0905 @qu-ngx 

---

Pull request by: Bao Ngo
