### PR TITLE
Update documentation, and CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,9 @@ if((NOT (WIN32 OR MSYS)) AND (SANITIZE))
   message("Not windows")
   add_compile_options(-fsanitize=leak)
 endif()
+if(CMAKE_BUILD_TYPE STREQUAL Debug)
+  add_compile_options(-fno-inline -fno-omit-frame-pointer)
+endif()
 
 # where all the libraries are
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,10 @@ elseif(CMAKE_BUILD_TYPE STREQUAL Debug)
   message("Building a debug version")
 endif()
 message(${CMAKE_SYSTEM_NAME})
+
+option(SANITIZE "Whether to turn on sanitization flags on Unix" OFF)
 # I tried this flag on Windows and it threw an error, so,
-if(NOT (WIN32 OR MSYS))
+if((NOT (WIN32 OR MSYS)) AND (SANITIZE))
   message("Not windows")
   add_compile_options(-fsanitize=leak)
 endif()

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -105,6 +105,14 @@ sudo groupadd docker
 sudo usermod -aG docker $USER
 ```
 
+- Then fork and clone the project and run:
+
+```bash
+cd smoldb
+code .
+```
+
+- Which opens VS Code at that directory.
 - If you're on VS Code, set up as follow:
   - Install extensions:
     - C/C++ extension pack, which also includes CMake Tools.
@@ -117,12 +125,14 @@ sudo usermod -aG docker $USER
     - GitHub Actions. Optional, only useful to check how your GitHub actions go.
     - GitHub Pull Request. Optional, since, browser.
   - After that, click the CMake icon on the left-hand-side bar.
+  This open the CMake extension menu.
   - In the "Configure" tab, choose the Clang kit.
-  - The extension should know enough to figure out the rest.
+  - In the "Debug" tab, choose either smoldb or smoldb install.
+    - If you choose smoldb install, remember to run this after every build
 
-> [!NOTE]
-> If CMake throws an error, delete and re-create the `build` directory first.
->
+    ```bash
+    cmake --install build
+    ```
 
 - If you're on NeoVim or any other editors using clang-analyzer, set up as follow:
   - Run the convenience script to generate a compile_commands.json:
@@ -132,9 +142,14 @@ sudo usermod -aG docker $USER
   ./cmake-default-init.sh
   # create a symlink at the project root
   ln -s build/compile_commands.json compile_commands.json
+  # build and install
+  cmake --build build && cmake --install build
   ```
 
   - After that, clang-analyzer should figure itself out.
+  - To debug the project, make sure you have nvim dap installed.
+  Preferably, configure C/C++ to use lldb-vscode.
+  - You should debug using the executable.
 
 ### For Windows system
 
@@ -163,6 +178,13 @@ sudo usermod -aG docker $USER
 - MSYS2 [following this link](https://www.mingw-w64.org/downloads/#msys2)
 - Docker. Optional, only for running dev container.
 - choco. Optional, to download Vale, necessary for editing documentation.
+  - To install choco, [follow this documentation](https://chocolatey.org/install#individual)
+  - To install Vale with choco, open Command Prompt as Administrator and run:
+
+  ```pwsh
+  choco install vale
+  ```
+
 - Then, do as follow:
 
 1. After downloading MSYS2, find the UCRT64 executable and run it.
@@ -173,8 +195,9 @@ sudo usermod -aG docker $USER
   # assuming you're on x86_64
   # if you're on an ARM machine, change x86_64 to aarch64
   # compiler
-  pacman -S git gcc clang ninja cmake \
-  mingw-w64-x86_64-clang-tools-extra
+  pacman -S mingw-w64-ucrt-x86_64-clang \
+  mingw-w64-ucrt-x86_64-ninja mingw-w64-ucrt-x86_64-cmake \
+  mingw-w64-ucrt-x86_64-clang-tools-extra
   pacman -Syuu
   ```
 
@@ -184,7 +207,16 @@ sudo usermod -aG docker $USER
 1. Press `Window`, search for "environment variables."
 2. Click on the first result, which leads to the list of environment variables.
 3. Click "Add," and paste in <install_path>\ucrt64\bin.
-4. Close the window.
+4. Close the window and terminal. After that, open Command Prompt.
+5. In Command Prompt, check if it can recognize the packages:
+
+```bash
+clang --version
+ninja --version
+cmake --version
+clang-format --version
+clang-tidy --version
+```
 
 - If you're on VS Code, set up as follow:
   - Install extensions:
@@ -197,23 +229,24 @@ sudo usermod -aG docker $USER
     only to configure YAML files, such as the .clang-format file.
     - GitHub Actions. Optional, only useful to check how your GitHub actions go.
     - GitHub Pull Request. Optional, since, browser.
-  - After that, click the CMake icon on the left-hand-side bar.
-  - In the "Configure" tab, choose the Clang kit.
-  - The extension should know enough to figure out the rest.
 
 - Now, fork this repository, then clone your fork, and do the setup:
 
 1. Open terminal, make sure you're at the root directory of this project.
 2. Run `code .`, which launches VS Code.
-3. In VS Code, create a new directory called "build"
-at the root directory of the project.
-4. Open the integrated terminal and run the following to build an executable.
-After that, run the executable:
+3. In VS Code, find the CMake extension icon. Click on it.
+A config menu is then opened.
+4. Inside CMake configuration menu, click "select kit," and choose the Clang kit.
+It should configure everything for you.
+5. Next, at the Debug section, choose any of them.
+6. Down at the Project Outline menu, click Build on the smoldb executable.
+7. Check that there is an executable inside the directory build.
+8. Run the following command after every rebuild to pull the executable to
+the project root, then run it:
 
-```bash
-./cmake-default-init.sh
-cd build && cmake --build .
-./smoldb.exe
+```pwsh
+cmake --install build
+.\smoldb.exe
 ```
 
 > [!NOTE]
@@ -221,3 +254,8 @@ cd build && cmake --build .
 > But, nothing unexpected.
 > If nothing happens, then it ran without an error.
 >
+
+## How-to
+
+- Build and run the executable
+  - Make sure you have follo

--- a/docs/dev-env.md
+++ b/docs/dev-env.md
@@ -1,5 +1,10 @@
 # Set up development environment
 
+> [!IMPORTANT]
+> This documentation focuses mainly on setting up VS Code.
+> If you want to set up NeoVim, you can issue a documentation update.
+>
+
 <!--toc:start-->
 - [Set up development environment](#set-up-development-environment)
   - [The lazy way](#the-lazy-way)
@@ -8,6 +13,7 @@
     - [For Windows system](#for-windows-system)
       - [Way 1](#way-1)
       - [Way 2](#way-2)
+    - [How-to](#how-to)
 <!--toc:end-->
 
 - There are 2 ways, the "lazy" way and the "normal" way.
@@ -156,7 +162,7 @@ code .
 > [!NOTE]
 > This part is mainly for building a Windows-native executable.
 > If you just need to see the thing run,
-> opt for the [dev container](#set-up-development-environment) way.
+> opt for the [dev container](#the-lazy-way) way.
 >
 
 #### Way 1
@@ -258,4 +264,54 @@ cmake --install build
 ## How-to
 
 - Build and run the executable
-  - Make sure you have follo
+  - Make sure you have followed the steps preceding.
+  - If you use VS Code, simply navigate to the CMake config menu,
+  and click Build on the smoldb executable.
+  - To build with command-line instead, run the following at the project root:
+
+  ```bash
+  cmake --build build
+  cmake --install build
+  ```
+
+- Debug
+  - First, build the executable in debug mode.
+  - If you're on VS Code, open the Command Palette with `Ctrl+Shift+P`,
+  find "CMake: Debug" and run.
+  - If you use NeoVim, use nvim-dap to debug.
+  - Or, if you're a gigachad and like gdb/lldb in the terminal, do it your way.
+  I have yet to reach that realm.
+
+- Format and lint your code
+  - You can use the convenience script:
+
+  ```bash
+  ./clang-format-lint-all.sh
+  ```
+
+  - In VS Code, you can also do as follow:
+    - Open Settings, find "format on save" and turn it on.
+    Then, every time you save, clang-format does its work.
+    - Then, find "code analysis," and tick the checkbox of
+    C/Cpp > Code analysis > Clang Tidy: Enabled and
+    C/Cpp > Code analysis: Run automatically
+  - This could throw you quite a lot of coding-style errors, as expected.
+
+- Format and lint the Markdown documentation
+  - Make sure to make markdownlint and vale installed.
+    - On VS Code, download the markdownlint and vale extensions,
+    then download the vale command-line tool.
+    - If you haven't, created a directory at your user root called `vale`,
+    and inside that, create a file called .vale.ini.
+    - Add the following to .vale.ini:
+
+    ```yaml
+    StylePath: .
+    Packages: Google
+    ```
+
+    - Save, open the command line, run the following to download the package:
+
+    ```bash
+    vale sync
+    ```


### PR DESCRIPTION
# Update documentation, and CMakeLists

- **What**:

Fix the Ming-gw64 command-line package download instructions to explicitly use `ucrt` packages.
Add general guide on how to debug, format, and lint your code. Add general guide on how to lint the Markdown docs.
I also made the -fsanitize=leak flag optional, and off by default.

- **Why**:

I realized the "generic" package on Ming-gw64 will download to all the places. So, specifying it's UCRT64 makes everything sit inside the UCRT64 directory.
Sanitization is a performance hit, so I let it be optional.

- **How**:

I updated the command to run inside UCRT64, and added a new section called "How-to" for general guide.
If you have any more questions, please create an Issue. Whatever question it is, will be updated on the "how-to."

- **Misc**:

With this out of the way, we are (almost) ready for doing some actual  code.

- **Tags**:

@qu-ngx @AbstractionHLR @BAOELIETRAN @bebeminhminh

---

Pull request by: Huy Nguyen
