### PR TITLE
Format, lint, and new lint script

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -1,0 +1,70 @@
+# This starter workflow is for a CMake project running on multiple platforms. There is a different starter workflow if you just want a single platform.
+# See: https://github.com/actions/starter-workflows/blob/main/ci/cmake-single-platform.yml
+name: CMake on multiple platforms
+
+on:
+  push:
+    branches: [ "beta-v0.0.1" ]
+  pull_request:
+    branches: [ "beta-v0.0.1" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      # Set fail-fast to false to ensure that feedback is delivered for all matrix combinations. Consider changing this to true when your workflow is stable.
+      fail-fast: false
+
+      # Set up a matrix to run the following 3 configurations:
+      # 1. <Windows, Release, latest MSVC compiler toolchain on the default runner image, default generator>
+      # 2. <Linux, Release, latest GCC compiler toolchain on the default runner image, default generator>
+      # 3. <Linux, Release, latest Clang compiler toolchain on the default runner image, default generator>
+      #
+      # To add more build types (Release, Debug, RelWithDebInfo, etc.) customize the build_type list.
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        build_type: [Release]
+        c_compiler: [gcc, clang, cl]
+        include:
+          - os: windows-latest
+            c_compiler: cl
+            cpp_compiler: cl
+          - os: ubuntu-latest
+            c_compiler: gcc
+            cpp_compiler: g++
+          - os: ubuntu-latest
+            c_compiler: clang
+            cpp_compiler: clang++
+        exclude:
+          - os: windows-latest
+            c_compiler: gcc
+          - os: windows-latest
+            c_compiler: clang
+          - os: ubuntu-latest
+            c_compiler: cl
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set reusable strings
+      # Turn repeated input strings (such as the build output directory) into step outputs. These step outputs can be used throughout the workflow file.
+      id: strings
+      shell: bash
+      run: |
+        echo "build-output-dir=${{ github.workspace }}/build" >> "$GITHUB_OUTPUT"
+
+    - name: Configure CMake
+      # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
+      # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
+      run: >
+        cmake -B ${{ steps.strings.outputs.build-output-dir }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
+        -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
+        -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -S ${{ github.workspace }}
+
+    - name: Build
+      # Build your program with the given configuration. Note that --config is needed because the default Windows generator is a multi-config generator (Visual Studio generator).
+      run: cmake --build ${{ steps.strings.outputs.build-output-dir }} --config ${{ matrix.build_type }}
+

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,93 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+  schedule:
+    - cron: '42 18 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    # Runner size impacts CodeQL analysis time. To learn more, please see:
+    #   - https://gh.io/recommended-hardware-resources-for-running-codeql
+    #   - https://gh.io/supported-runners-and-hardware-resources
+    #   - https://gh.io/using-larger-runners (GitHub.com only)
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    timeout-minutes: ${{ (matrix.language == 'swift' && 120) || 360 }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        - language: c-cpp
+          build-mode: autobuild
+        # CodeQL supports the following values keywords for 'language': 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'swift'
+        # Use `c-cpp` to analyze code written in C, C++ or both
+        # Use 'java-kotlin' to analyze code written in Java, Kotlin or both
+        # Use 'javascript-typescript' to analyze code written in JavaScript, TypeScript or both
+        # To learn more about changing the languages that are analyzed or customizing the build mode for your analysis,
+        # see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/customizing-your-advanced-setup-for-code-scanning.
+        # If you are analyzing a compiled language, you can modify the 'build-mode' for that language to customize how
+        # your codebase is analyzed, see https://docs.github.com/en/code-security/code-scanning/creating-an-advanced-setup-for-code-scanning/codeql-code-scanning-for-compiled-languages
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v3
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: ${{ matrix.build-mode }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+    # If the analyze step fails for one of the languages you are analyzing with
+    # "We were unable to automatically build your code", modify the matrix above
+    # to set the build mode to "manual" for that language. Then modify this step
+    # to build your code.
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
+    - if: matrix.build-mode == 'manual'
+      shell: bash
+      run: |
+        echo 'If you are using a "manual" build mode for one or more of the' \
+          'languages you are analyzing, replace this with the commands to build' \
+          'your code, for example:'
+        echo '  make bootstrap'
+        echo '  make release'
+        exit 1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:${{matrix.language}}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,12 @@ project(
   LANGUAGES C
   VERSION 0.0)
 
-# enforcing some standards
-set(CMAKE_C_STANDARD 23)
-set(CMAKE_C_STANDARD_REQUIRED True)
+# MSVC somehow breaks at this option
+if(NOT MSVC)
+  # enforcing some standards
+  set(CMAKE_C_STANDARD 23)
+  set(CMAKE_C_STANDARD_REQUIRED True)
+endif()
 
 # build steps for this project:
 

--- a/clang-format-lint-all.sh
+++ b/clang-format-lint-all.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
-for item in `find . -not -path './build/*' -name '*.c' -or -name '*.h' -or -name '*.h.in'`; do
+find_cmd=`find './src' -name '*.c' -or -name '*.cpp*' -or -name '*.h' -or -name '*.h.in'`
+find_cmd=$find_cmd `find './test' -name '*.c' -or -name '*.cpp*' -or -name '*.h' -or -name '*.h.in'`
+
+for item in $find_cmd; do
   clang-tidy ${item}
   clang-format ${item} -i
 done

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8"/>
+    <title>Smoldb Project</title>
+    <meta name="viewport" content="width=device-width"/>
+  </head>
+  <body>
+    <h3>Currently, there's nothing here yet. I just include this so that Github doesn't scream an error :).</h3>
+  </body>
+</html>

--- a/include/smoldb/smoldb.h
+++ b/include/smoldb/smoldb.h
@@ -4,7 +4,7 @@
  * yet.
  */
 
-#ifndef __SMOLDB_H__
-#define __SMOLDB_H__
+#ifndef SMOLDB_H
+#define SMOLDB_H
 
-#endif // !__SMOLDB_H__
+#endif  // !SMOLDB_H

--- a/src/cli/cli-handler.c
+++ b/src/cli/cli-handler.c
@@ -1,6 +1,8 @@
 #include "cli-handler.h"
-#include "retval.h"
+
 #include <stdlib.h>
+
+#include "retval.h"
 
 struct InputBuf {
   char *buffer;
@@ -8,12 +10,14 @@ struct InputBuf {
 };
 
 int smoldb_new_input_buf(InputBuf **buf) {
-  if (buf == NULL)
+  if (buf == NULL) {
     return SMOLDB_NULL_PTR_TO_REF_ERR;
+  }
 
   (*buf) = (InputBuf *)malloc(sizeof(InputBuf));
-  if ((*buf) == NULL)
+  if ((*buf) == NULL) {
     return SMOLDB_ALLOC_ERR;
+  }
 
   (*buf)->buffer = NULL;
   (*buf)->buf_len = 0;
@@ -22,8 +26,9 @@ int smoldb_new_input_buf(InputBuf **buf) {
 }
 
 int smoldb_free_input_buf(InputBuf **buf) {
-  if (buf == NULL)
+  if (buf == NULL) {
     return SMOLDB_ALLOC_SUCCESS;
+  }
 
   free((*buf)->buffer);
   (*buf)->buffer = NULL;

--- a/src/cli/cli-handler.h
+++ b/src/cli/cli-handler.h
@@ -3,17 +3,15 @@
  * @brief Declares a set of functions to receive and handle user inputs
  */
 
-#ifndef __SMOLDB_CLI_HANDLER_H__
-#define __SMOLDB_CLI_HANDLER_H__
+#ifndef SMOLDB_CLI_HANDLER_H
+#define SMOLDB_CLI_HANDLER_H
 
 #include "general.h"
-#include "retval.h"
-#include <stdlib.h>
 
 /* So that the code runs with Cpp */
 #ifdef __cplusplus
 extern "C" {
-#endif // __cplusplus
+#endif  // __cplusplus
 
 /**
  * @typedef InputBuf
@@ -43,6 +41,6 @@ SMOL_API int smoldb_free_input_buf(InputBuf **buf);
 
 #ifdef __cplusplus
 }
-#endif // __cplusplus
+#endif  // __cplusplus
 
-#endif // !__SMOLDB_CLI_HANDLER_H__
+#endif  // !SMOLDB_CLI_HANDLER_H

--- a/src/entry.c
+++ b/src/entry.c
@@ -1,10 +1,12 @@
-#include "cli-handler.h"
 #include <stdlib.h>
+
+#include "cli-handler.h"
+#include "retval.h"
 
 int main(int argc, char *argv[]) {
   InputBuf *buf;
   int retval = smoldb_new_input_buf(&buf);
-  if(retval == SMOLDB_ALLOC_ERR){
+  if (retval == SMOLDB_ALLOC_ERR) {
     smoldb_free_input_buf(&buf);
     return EXIT_FAILURE;
   }

--- a/src/general.h
+++ b/src/general.h
@@ -1,10 +1,10 @@
-#ifndef __SMOLDB_GENERAL_H__
-#define __SMOLDB_GENERAL_H__
+#ifndef SMOLDB_GENERAL_H
+#define SMOLDB_GENERAL_H
 
 #define Smoldb_VERSION_MAJOR "0"
 #define Smoldb_VERSION_MINOR "0"
 
 #define SMOL_API extern
-#define SMOL_INTERNAL static
+#define SMOL_INTERNAL extern
 
-#endif // !__SMOLDB_GENERAL_H__
+#endif  // !SMOLDB_GENERAL_H

--- a/src/general.h.in
+++ b/src/general.h.in
@@ -1,5 +1,5 @@
-#ifndef __SMOLDB_GENERAL_H__
-#define __SMOLDB_GENERAL_H__
+#ifndef SMOLDB_GENERAL_H
+#define SMOLDB_GENERAL_H
 
 #define Smoldb_VERSION_MAJOR "@Smoldb_VERSION_MAJOR@"
 #define Smoldb_VERSION_MINOR "@Smoldb_VERSION_MINOR@"
@@ -7,4 +7,4 @@
 #define SMOL_API extern
 #define SMOL_INTERNAL static
 
-#endif // !__SMOLDB_GENERAL_H__
+#endif  // !SMOLDB_GENERAL_H

--- a/src/internal/btree.h
+++ b/src/internal/btree.h
@@ -1,6 +1,6 @@
-#ifndef __SMOL_DB_INTERNAL_BTREE_H__
-#define __SMOL_DB_INTERNAL_BTREE_H__
+#ifndef SMOLDB_INTERNAL_BTREE_H
+#define SMOLDB_INTERNAL_BTREE_H
 
 typedef struct BTree BTree;
 
-#endif // !__SMOL_DB_INTERNAL_BTREE_H__
+#endif  // !SMOL_DB_INTERNAL_BTREE_H

--- a/src/internal/sql.h
+++ b/src/internal/sql.h
@@ -1,6 +1,6 @@
-#ifndef __SMOLDB_INTERNAL_SQL_H__
-#define __SMOLDB_INTERNAL_SQL_H__
+#ifndef SMOLDB_INTERNAL_SQL_H
+#define SMOLDB_INTERNAL_SQL_H
 
 typedef struct SqlParser SqlParser;
 
-#endif // !__SMOLDB_INTERNAL_SQL_H__
+#endif  // !SMOLDB_INTERNAL_SQL_H

--- a/src/internal/token-hash.h
+++ b/src/internal/token-hash.h
@@ -1,6 +1,6 @@
-#ifndef __SMOL_DB_INTERNAL_TOKEN_HASH_H__
-#define __SMOL_DB_INTERNAL_TOKEN_HASH_H__
+#ifndef SMOLDB_INTERNAL_TOKEN_HASH_H
+#define SMOLDB_INTERNAL_TOKEN_HASH_H
 
 typedef struct TokenHashTable TokenHashTable;
 
-#endif // !__SMOL_DB_INTERNAL_TOKEN_HASH_H__
+#endif  // !SMOLDB_INTERNAL_TOKEN_HASH_H

--- a/src/internal/tokens.h
+++ b/src/internal/tokens.h
@@ -1,8 +1,8 @@
-#ifndef __SMOL_DB_INTERNAL_TOKENS_H__
-#define __SMOL_DB_INTERNAL_TOKENS_H__
+#ifndef SMOLDB_INTERNAL_TOKENS_H
+#define SMOLDB_INTERNAL_TOKENS_H
 
 #include "general.h"
 
 SMOL_INTERNAL int smoldb_handle_tokens(const char *cmdline);
 
-#endif // !__SMOL_DB_INTERNAL_TOKENS_H__
+#endif  // !SMOLDB_INTERNAL_TOKENS_H

--- a/src/retval.h
+++ b/src/retval.h
@@ -1,5 +1,5 @@
-#ifndef __SMOLDB_RETVAL_H__
-#define __SMOLDB_RETVAL_H__
+#ifndef SMOLDB_RETVAL_H
+#define SMOLDB_RETVAL_H
 
 /**
  * @typedef SMOL_ALLOC_RETVAL
@@ -31,4 +31,4 @@ typedef enum SMOL_INPUT_READ_RETVAL {
   SMOLDB_READ_ERR,
 } SMOL_INPUT_READ_RETVAL;
 
-#endif // !__SMOLDB_RETVAL_H__
+#endif  // !SMOLDB_RETVAL_H


### PR DESCRIPTION
# Format, lint and new linting script

- **What**:

Formatted all current source file. Update linting script to exclude build dir and include test dir. Also included 2 new GitHub actions, CMake multi-platform build and CodeQL.

- **Why**:

Format code so that it follows the format and linting options listed in .clang-format and .clang-tidy files.

I like the green tick effect when all GitHub actions run correctly :). To be fair, it isn't very useful for a project of this size.

- **How**:

I simply run formatting for all scripts, then go to each one and modify accordingly to the linter.

I added the GitHub action scripts, using the default provided by GitHub.

- **Tags**:

@qu-ngx @BAOELIETRAN @AbstractionHLR @bebeminhminh @aqt169

---

Pull request by: Huy Nguyen
