### PR TITLE
Quick fix: static to extern for smoldb-internal

### DIFF
--- a/src/general.h.in
+++ b/src/general.h.in
@@ -5,6 +5,6 @@
 #define Smoldb_VERSION_MINOR "@Smoldb_VERSION_MINOR@"
 
 #define SMOL_API extern
-#define SMOL_INTERNAL static
+#define SMOL_INTERNAL extern
 
 #endif  // !SMOLDB_GENERAL_H


### PR DESCRIPTION
# Change static to extern for macro SMOL_INTERNAL

-  **What**:

Read title

- **Why**:

Without this, header files cannot mark a method as SMOL_INTERNAL without defining the method also, which is not what we want for a header file.

---

Pull request by: Huy Nguyen
